### PR TITLE
Fix postgreSQL version

### DIFF
--- a/jumbo/core/config/versions.json
+++ b/jumbo/core/config/versions.json
@@ -5,8 +5,8 @@
       "versions": {
         "9.3": "https://download.postgresql.org/pub/repos/yum/9.3/redhat/rhel-7-x86_64/pgdg-centos93-9.3-3.noarch.rpm",
         "9.4": "https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-centos94-9.4-3.noarch.rpm",
-        "9.5": "https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm",
-        "9.6": "https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm",
+        "9.5": "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm",
+        "9.6": "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm",
         "10": "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
       },
       "default": "10"

--- a/jumbo/core/config/versions.json
+++ b/jumbo/core/config/versions.json
@@ -7,7 +7,7 @@
         "9.4": "https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-centos94-9.4-3.noarch.rpm",
         "9.5": "https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm",
         "9.6": "https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm",
-        "10": "https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm"
+        "10": "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
       },
       "default": "10"
     },


### PR DESCRIPTION
When starting a new cluster:

```
jumbo (mycluster) > start
```

There is an error:

```
TASK [postgres : Download version 10] ******************************************
fatal: [master01]: FAILED! => {"changed": false, "msg": "Failure downloading https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm, HTTP Error 404: Not Found"}
```

This commit fixes the downloading source.